### PR TITLE
Increased code speed for impedance analyzer

### DIFF
--- a/src/TcpInstruments.jl
+++ b/src/TcpInstruments.jl
@@ -88,7 +88,6 @@ export set_temp_unit_celsius, set_temp_unit_farenheit, set_temp_unit_kelvin
 export get_temp_unit
 
 # Impedance
-export read_float32
 export get_bandwidth, set_bandwidth
 export get_frequency_limits, set_frequency_limits
 export get_num_data_points, set_num_data_points

--- a/src/TcpInstruments.jl
+++ b/src/TcpInstruments.jl
@@ -88,6 +88,7 @@ export set_temp_unit_celsius, set_temp_unit_farenheit, set_temp_unit_kelvin
 export get_temp_unit
 
 # Impedance
+export read_float32
 export get_bandwidth, set_bandwidth
 export get_frequency_limits, set_frequency_limits
 export get_num_data_points, set_num_data_points

--- a/src/impedance_analyzer/Agilent4294A.jl
+++ b/src/impedance_analyzer/Agilent4294A.jl
@@ -86,7 +86,7 @@ function perform_single_acquisition(ia::Instr{Agilent4294A})
 end
 
 
-# this function should be blocking
+# this function is blocking (lightly tested only)
 function get_acquisition_status(ia::Instr{Agilent4294A})
     write(ia, "*OPC?")
     output = read(ia)
@@ -137,15 +137,15 @@ end
 
 
 function read_float32(ia::Instr{Agilent4294A})
-    num_acq_points = get_num_data_points(ia)
+    num_data_points = get_num_data_points(ia)
     num_values_per_point = 2
     num_bytes_per_point = 4
-    num_data_bytes = num_acq_points * num_values_per_point * num_bytes_per_point
+    num_data_bytes = num_data_points * num_values_per_point * num_bytes_per_point
     
-    write(ia, "FORM2")
-    write(ia, "OUTPDTRC?")
-    read_data_file_header(ia)
-    data = ntoh.(reinterpret(Float32, read_num_bytes(ia, num_data_bytes)))
+    set_data_output_to_float32(ia)
+    request_data_trace(ia)
+    get_data_header(ia)
+    data = ntoh.(reinterpret(Float32, read_num_bytes(ia, num_data_bytes)))       
     # read end of line character
     read(ia)
 
@@ -153,10 +153,22 @@ function read_float32(ia::Instr{Agilent4294A})
 end
 
 
-function read_data_file_header(ia::Instr{Agilent4294A})
+function set_data_output_to_float32(ia::Instr{Agilent4294A})
+    write(ia, "FORM2")
+    return nothing
+end
+
+
+function request_data_trace(ia::Instr{Agilent4294A})
+    write(ia, "OUTPDTRC?")
+    return nothing
+end
+
+
+function get_data_header(ia::Instr{Agilent4294A})
     num_bytes_in_header = 8
-    file_header = read_num_bytes(ia, num_bytes_in_header)
-    return file_header
+    data_header = read_num_bytes(ia, num_bytes_in_header)
+    return data_header
 end
 
 

--- a/src/impedance_analyzer/Agilent4294A.jl
+++ b/src/impedance_analyzer/Agilent4294A.jl
@@ -173,25 +173,6 @@ function read_num_bytes(ia::Instr{Agilent4294A}, num_bytes)
 end
 
 
-function get_frequency_range(ia::Instr{Agilent4294A})
-    write(ia, "STAR?")
-    freq_lower_bound = parse(Int, read(ia))
-    write(ia, "STOP?")
-    freq_upper_bound = parse(Int, read(ia))
-    return freq_lower_bound, freq_upper_bound
-end
-
-
-function set_frequency_range(ia::Instr{Agilent4294A}, lower_bound, upper_bound)
-    if lower_bound > upper_bound
-        error("Lower bound ($lower_bound) is larger than upper bound ($upper_bound)")
-    end
-    write(ia, "STAR $(lower_bound)MHZ")
-    write(ia, "STOP $(upper_bound)MHZ")
-    return nothing
-end
-
-
 function set_num_acq_points(ia::Instr{Agilent4294A}, num_acq_points)
     write(ia, "POIN $num_acq_points")
     return nothing

--- a/src/impedance_analyzer/Agilent4294A.jl
+++ b/src/impedance_analyzer/Agilent4294A.jl
@@ -171,3 +171,22 @@ function read_num_bytes(ia::Instr{Agilent4294A}, num_bytes)
     output = read(ia.sock, num_bytes)
     return output
 end
+
+
+function get_frequency_range(ia::Instr{Agilent4294A})
+    write(ia, "STAR?")
+    freq_lower_bound = parse(Int, read(ia))
+    write(ia, "STOP?")
+    freq_upper_bound = parse(Int, read(ia))
+    return freq_lower_bound, freq_upper_bound
+end
+
+
+function set_frequency_range(ia::Instr{Agilent4294A}, lower_bound, upper_bound)
+    if lower_bound > upper_bound
+        error("Lower bound ($lower_bound) is larger than upper bound ($upper_bound)")
+    end
+    write(ia, "STAR $(lower_bound)MHZ")
+    write(ia, "STOP $(upper_bound)MHZ")
+    return nothing
+end

--- a/src/impedance_analyzer/Agilent4294A.jl
+++ b/src/impedance_analyzer/Agilent4294A.jl
@@ -137,7 +137,7 @@ end
 
 
 function read_float32(ia::Instr{Agilent4294A})
-    num_acq_points = get_num_acq_points(ia)
+    num_acq_points = get_num_data_points(ia)
     num_values_per_point = 2
     num_bytes_per_point = 4
     num_data_bytes = num_acq_points * num_values_per_point * num_bytes_per_point
@@ -153,13 +153,6 @@ function read_float32(ia::Instr{Agilent4294A})
 end
 
 
-function get_num_acq_points(ia::Instr{Agilent4294A})
-    write(ia, "POIN?")
-    num_acq_points = read(ia)
-    return parse(Int, num_acq_points)
-end
-
-
 function read_data_file_header(ia::Instr{Agilent4294A})
     num_bytes_in_header = 8
     file_header = read_num_bytes(ia, num_bytes_in_header)
@@ -170,10 +163,4 @@ end
 function read_num_bytes(ia::Instr{Agilent4294A}, num_bytes)
     output = read(ia.sock, num_bytes)
     return output
-end
-
-
-function set_num_acq_points(ia::Instr{Agilent4294A}, num_acq_points)
-    write(ia, "POIN $num_acq_points")
-    return nothing
 end

--- a/src/impedance_analyzer/Agilent4294A.jl
+++ b/src/impedance_analyzer/Agilent4294A.jl
@@ -190,3 +190,9 @@ function set_frequency_range(ia::Instr{Agilent4294A}, lower_bound, upper_bound)
     write(ia, "STOP $(upper_bound)MHZ")
     return nothing
 end
+
+
+function set_num_acq_points(ia::Instr{Agilent4294A}, num_acq_points)
+    write(ia, "POIN $num_acq_points")
+    return nothing
+end

--- a/src/impedance_analyzer/Agilent4294A.jl
+++ b/src/impedance_analyzer/Agilent4294A.jl
@@ -149,6 +149,10 @@ function read_float32(ia::Instr{Agilent4294A})
     # read end of line character
     read(ia)
 
+    if length(data) != num_data_points
+        error("Transferred data did not have the expected number of data points (transferred: $(length(data)), expected: $num_data_points)")
+    end
+
     return data
 end
 

--- a/src/impedance_analyzer/all.jl
+++ b/src/impedance_analyzer/all.jl
@@ -54,15 +54,22 @@ end
     set_num_data_points(instr, num_points)
 
 """
-set_num_data_points(obj::Instr{T}, n) where (T <: ImpedanceAnalyzer) =
-    write(obj, "POIN $n")
+function set_num_data_points(ia::Instr{T}, num_data_points) where T <: ImpedanceAnalyzer
+    write(ia, "POIN $num_data_points")
+    return nothing
+end
+
 
 """
     get_num_data_points(instr)
 
 """
-get_num_data_points(obj::Instr{T}) where (T <: ImpedanceAnalyzer) =
-    i_query(obj, "POIN?")
+function get_num_data_points(ia::Instr{T}) where T <: ImpedanceAnalyzer
+    write(ia, "POIN?")
+    num_data_points = parse(Int64, read(ia))
+    return num_data_points
+end
+
 
 """
     get_volt_dc(instr)


### PR DESCRIPTION
Increased code speed for the following:
- Data transfer (240x faster)
- Frequency limit query (20x faster)
- Num data points query (2x faster)

Faster data transfer closes #60 
`get_impedance()` outputting complex impedance closes #57