### PR TITLE
Save full oscilloscope info struct & voltage trace array to Matlab files

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -39,7 +39,7 @@ data to matlab by using the format=:matlab keyword argument
 function save(data; filename = "", format = :julia)
     if isempty(filename)
         t = Dates.format(Dates.now(), "yy-mm-dd_HH:MM:SS")
-        filename = "scan_" * t
+        filename = "InstrumentData_" * t
     end
     if format == :julia
         @save (filename * ".jld2") data

--- a/src/util.jl
+++ b/src/util.jl
@@ -44,11 +44,18 @@ function save(data; filename = "", format = :julia)
     if format == :julia
         @save (filename * ".jld2") data
     elseif format == :matlab
+        file = matopen(filename * ".mat", "w"; compress=true)
         if isa(data, ScopeData)
-            data = ScopeData(data.info, ustrip.(data.volt), ustrip.(data.time))
+            info = data.info
+            volt = ustrip.(data.volt)
+            time = ustrip.(data.time)
+            write(file, "info", info)
+            write(file, "volt", volt)
+            write(file, "time", time)
+        else
+            write(file, "data", raw.(data))
         end
-        file = matopen(filename * ".mat", "w")
-        write(file, "data", raw.(data))
+
         close(file)
     end
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -45,7 +45,7 @@ function save(data; filename = "", format = :julia)
         @save (filename * ".jld2") data
     elseif format == :matlab
         if isa(data, ScopeData)
-            data = ScopeData(data.info, ustrip(data.volt), data.time)
+            data = ScopeData(data.info, ustrip.(data.volt), ustrip.(data.time))
         end
         file = matopen(filename * ".mat", "w")
         write(file, "data", raw.(data))


### PR DESCRIPTION
This PR enables saving of oscilloscope data to Matlab files containing an easy to read "info" struct, a "volt" (Float64 array), and "time" (Float64 array) vectors