### PR TITLE
Save multi-channel ScopeData

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -64,6 +64,21 @@ function save_to_matfile(matfile, data::ScopeData)
     write(matfile, "time_unit", time_unit)
 end
 
+function save_to_matfile(matfile, scope_data_array::Array{ScopeData})
+    array_length = length(scope_data_array)
+    data_template = Matrix{Any}(nothing, 1, array_length)
+    data = Dict("info"=>copy(data_template), "volt"=>copy(data_template), "time"=>copy(data_template), "volt_unit"=>copy(data_template), "time_unit"=>copy(data_template))
+    for idx = 1:array_length
+        scope_data = scope_data_array[idx]
+        data["info"][idx] = scope_data.info
+        data["volt"][idx] = ustrip.(scope_data.volt)
+        data["time"][idx] = ustrip.(scope_data.time)
+        data["volt_unit"][idx] = string(unit(scope_data.volt[1]))
+        data["time_unit"][idx] = string(unit(scope_data.time[1]))
+    end
+    write(matfile, "data", data)
+end
+
 function save_to_matfile(matfile, data::ImpedanceAnalyzerData)
     info = Dict()
     for fieldname in fieldnames(typeof(data.info))

--- a/src/util.jl
+++ b/src/util.jl
@@ -64,19 +64,18 @@ function save_to_matfile(matfile, data::ScopeData)
     write(matfile, "time_unit", time_unit)
 end
 
-function save_to_matfile(matfile, scope_data_array::Array{ScopeData})
-    array_length = length(scope_data_array)
-    data_template = Matrix{Any}(nothing, 1, array_length)
-    data = Dict("info"=>copy(data_template), "volt"=>copy(data_template), "time"=>copy(data_template), "volt_unit"=>copy(data_template), "time_unit"=>copy(data_template))
+function save_to_matfile(matfile, data_array::Array{ScopeData})
+    array_length = length(data_array)
     for idx = 1:array_length
-        scope_data = scope_data_array[idx]
-        data["info"][idx] = scope_data.info
-        data["volt"][idx] = ustrip.(scope_data.volt)
-        data["time"][idx] = ustrip.(scope_data.time)
-        data["volt_unit"][idx] = string(unit(scope_data.volt[1]))
-        data["time_unit"][idx] = string(unit(scope_data.time[1]))
+        data_dict = Dict()
+        scope_data = data_array[idx]
+        data_dict["info"] = scope_data.info
+        data_dict["volt"] = ustrip.(scope_data.volt)
+        data_dict["time"] = ustrip.(scope_data.time)
+        data_dict["volt_unit"] = string(unit(scope_data.volt[1]))
+        data_dict["time_unit"] = string(unit(scope_data.time[1]))
+        write(matfile, "channel_$(scope_data.info.channel)", data_dict)
     end
-    write(matfile, "data", data)
 end
 
 function save_to_matfile(matfile, data::ImpedanceAnalyzerData)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,8 +18,8 @@ const A = u"A"
             @test length(data.time) == length(data.volt)
             @test data.volt[1] isa Unitful.Voltage
 
-            time_no_units = ustrip.(TcpInstruments.raw.(data.time))
-            volt_no_units = ustrip.(TcpInstruments.raw.(data.volt))
+            time_no_units = TcpInstruments.raw.(data.time)
+            volt_no_units = TcpInstruments.raw.(data.volt)
             time_unit = string(unit(data.time[1]))
             volt_unit = string(unit(data.volt[1]))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,18 +12,18 @@ const A = u"A"
     @testset "Fake Scope" begin
         f = initialize(TcpInstruments.FakeDSOX4034A)
 
-        data = get_data(f, 1)
-        @test data isa TcpInstruments.ScopeData
-        @test length(data.time) == length(data.volt)
-        @test data.volt[1] isa Unitful.Voltage
+        @testset "Save single ch data" begin
+            data = get_data(f, 1)
+            @test data isa TcpInstruments.ScopeData
+            @test length(data.time) == length(data.volt)
+            @test data.volt[1] isa Unitful.Voltage
 
-        @testset "Save scope data" begin
             time_no_units = ustrip.(TcpInstruments.raw.(data.time))
             volt_no_units = ustrip.(TcpInstruments.raw.(data.volt))
             time_unit = string(unit(data.time[1]))
             volt_unit = string(unit(data.volt[1]))
 
-            save_filename = "./scope_save_data"
+            save_filename = "./single_ch_scope_data"
             save(data, filename=save_filename, format=:matlab)
             data_loaded = load(save_filename * ".mat")
             for key in keys(data_loaded["info"])
@@ -36,9 +36,27 @@ const A = u"A"
             rm(save_filename * ".mat")
         end
 
-        data = get_data(f, [1,2,3,4])
-        @test length(data) == 4
-        # TODO: fix bug where saving multichannel scope data fails (output is a vector of ScopeData)
+        @testset "Save multi ch data" begin
+            data = get_data(f, [1,2,3,4])
+            @test length(data) == 4
+            
+            save_filename = "./multi_ch_scope_data"
+            save(data, filename=save_filename, format=:matlab)
+            
+            data_loaded = load(save_filename * ".mat")
+            for idx = 1:length(data)
+                pre_save_data = data[idx]
+                post_save_data = data_loaded["channel_$(idx)"]
+                for key in keys(post_save_data["info"])
+                    @test post_save_data["info"][key] == getproperty(pre_save_data.info, Symbol(key))
+                end
+                @test post_save_data["time"] == ustrip.(pre_save_data.time)
+                @test post_save_data["volt"] == ustrip.(pre_save_data.volt)
+                @test string(post_save_data["time_unit"]) == string(unit(pre_save_data.time[1]))
+                @test string(post_save_data["volt_unit"]) == string(unit(pre_save_data.volt[1]))
+            end
+            rm(save_filename * ".mat")
+        end
     end
 
     @testset "Util Functions" begin


### PR DESCRIPTION
Closes #86 

I wasn't able to save the ScopeData as a struct array, so instead, up to four variables named `channel_[#]` will be created

To confirm that MAT.jl can't be used to save struct arrays, the following sequence of steps were performed:
1. Create a struct array in MATLAB
2. Save struct array to matfile
3. Open matfile in Julia
4. Save the Julia output to a new matfile
5. Open the new matfile in MATLAB

The output is a struct of cell arrays instead of a struct array