### PR TITLE
Fixed errors due to query timeouts

### DIFF
--- a/src/TcpInstruments.jl
+++ b/src/TcpInstruments.jl
@@ -65,6 +65,7 @@ export save, load
 export initialize, terminate, reset
 export remote_mode, local_mode
 export query, write, info, connect!, close!
+export clear_buffer
 
 # Power Supply
 export enable_output, disable_output, get_output_status

--- a/src/impedance_analyzer/Agilent4294A.jl
+++ b/src/impedance_analyzer/Agilent4294A.jl
@@ -33,7 +33,11 @@ end
 
 Returns oscillator (ac) voltage
 """
-get_volt_ac(i::Instr{Agilent4294A}) = f_query(i, "POWE?") * V
+function get_volt_ac(ia::Instr{Agilent4294A})
+    write(ia, "POWE?")
+    volt_ac = parse(Float64, read(ia)) * u"V"
+    return volt_ac
+end
 
 """
     set_volt_ac(instr, voltage)

--- a/src/impedance_analyzer/agilent_common.jl
+++ b/src/impedance_analyzer/agilent_common.jl
@@ -179,7 +179,12 @@ end
     get_volt_dc(ia::Instr{<:AgilentImpedAnalyzer})
 
 """
-get_volt_dc(obj::Instr{<:AgilentImpedAnalyzer}) = f_query(obj, "DCV?") * V
+function get_volt_dc(ia::Instr{<:AgilentImpedAnalyzer})
+    write(ia, "DCV?")
+    volt_dc = parse(Float64, read(ia)) * u"V"
+    return volt_dc
+end
+
 
 """
     set_volt_dc(ia::Instr{<:AgilentImpedAnalyzer}, volts)

--- a/src/instrument.jl
+++ b/src/instrument.jl
@@ -218,3 +218,25 @@ f_query(obj, ins; timeout=0.5) = parse(Float64, query(obj, ins; timeout=timeout)
 Differs from [query](@ref) in that it will return an Int64 and not a String
 """
 i_query(obj, ins; timeout=0.5) = parse(Int64, query(obj, ins; timeout=timeout))
+
+
+"""
+    clear_buffer(instr::Instrument)
+
+Remove any unread data from the instrument buffer
+"""
+function clear_buffer(instr::Instrument)
+    while !isnothing(read_with_timeout(instr, 0.5))
+    end
+    return nothing
+end
+
+function read_with_timeout(instr::Instrument, timeout)
+    task = @spawn read(instr)
+    result = timedwait(() -> task.state != :runnable, timeout; pollint=0.05)
+    if result == :ok
+        return fetch(task)
+    elseif result == :timed_out
+        return nothing
+    end
+end

--- a/src/instrument.jl
+++ b/src/instrument.jl
@@ -237,6 +237,7 @@ function read_with_timeout(instr::Instrument, timeout)
     if result == :ok
         return fetch(task)
     elseif result == :timed_out
+        schedule(task, InterruptException(), error=true)
         return nothing
     end
 end


### PR DESCRIPTION
Closes #101
Closes #102 
Closes #103 

Alternatively, `get_volt_dc()` and `get_volt_ac()` could've been refactored to use `f_query(; timeout=0)`. The current change was made to maintain consistency with the rest of the impedance analyzer `get` functions